### PR TITLE
Replace deprecated library block_cipher with cipher

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,7 +34,7 @@ dependencies = [
 
 [[package]]
 name = "tea-soft"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "byteorder",
  "cipher",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7,26 +7,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc52553543ecb104069b0ff9e0fcc5c739ad16202935528a112d974e8f1a4ee8"
 
 [[package]]
-name = "block-cipher"
-version = "0.8.0"
+name = "byteorder"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f337a3e6da609650eb74e02bc9fac7b735049f7623ab12f2e4c719316fcc7e80"
+checksum = "ae44d1a3d5a19df61dd0c8beb138458ac2a53a7ac09eba97d55592540004306b"
+
+[[package]]
+name = "cipher"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12f8e7987cbd042a63249497f41aed09f8e65add917ea6566effbc56578d6801"
 dependencies = [
  "blobby",
  "generic-array",
 ]
 
 [[package]]
-name = "byteorder"
-version = "1.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
-
-[[package]]
 name = "generic-array"
-version = "0.14.3"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60fb4bb6bba52f78a471264d9a3b7d026cc0af47b22cd2cffbc0b787ca003e63"
+checksum = "501466ecc8a30d1d3b7fc9229b122b2ce8ed6e9d9223f1138d4babb253e51817"
 dependencies = [
  "typenum",
  "version_check",
@@ -36,8 +36,8 @@ dependencies = [
 name = "tea-soft"
 version = "0.2.0"
 dependencies = [
- "block-cipher",
  "byteorder",
+ "cipher",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,10 +20,10 @@ exclude = [
 default-features = false
 version = "1"
 
-[dependencies.block-cipher]
-version = "0.8"
+[dependencies.cipher]
+version = "0.2"
 
-[dev-dependencies.block-cipher]
+[dev-dependencies.cipher]
 features = ["dev"]
-version = "0.8"
+version = "0.2"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tea-soft"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Youmu"]
 edition = "2018"
 description = "TEA block cipher"

--- a/src/dev.rs
+++ b/src/dev.rs
@@ -3,7 +3,7 @@
 #[cfg_attr(docsrs, doc(cfg(feature = "dev")))]
 macro_rules! bench {
     ($cipher:path, $key_len:expr) => {
-        block_cipher::bench!($cipher, $key_len);
+        cipher::block_cipher_bench!($cipher, $key_len);
 
 		#[bench]
         pub fn encrypt_blocks(bh: &mut Bencher) {

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -1,10 +1,10 @@
-pub use block_cipher::{BlockCipher, NewBlockCipher};
+pub use cipher::{BlockCipher, NewBlockCipher};
 use core::ops::{BitXor, Shl, Shr};
 
 use byteorder::{ByteOrder, BigEndian};
 
-use block_cipher::consts::{U4, U8, U16};
-use block_cipher::generic_array::GenericArray;
+use cipher::consts::{U4, U8, U16};
+use cipher::generic_array::GenericArray;
 
 use crate::simd::{WrapArithmetic, slice_block, unslice_block};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,7 +26,7 @@
 #![deny(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms)]
 
-pub use block_cipher;
+pub use cipher::block as block_cipher;
 
 mod dev;
 mod impls;

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -2,8 +2,8 @@
 //! http://www.cix.co.uk/~klockstone/teavect.htm
 #![no_std]
 
-use block_cipher::new_test;
+use cipher::block_cipher_test;
 
-new_test!(tea16_test, "tea16", tea_soft::Tea16);
-new_test!(tea32_test, "tea32", tea_soft::Tea32);
-new_test!(tea64_test, "tea64", tea_soft::Tea64);
+block_cipher_test!(tea16_test, "tea16", tea_soft::Tea16);
+block_cipher_test!(tea32_test, "tea32", tea_soft::Tea32);
+block_cipher_test!(tea64_test, "tea64", tea_soft::Tea64);


### PR DESCRIPTION
The block-cipher and stream-cipher crates have been merged into the new cipher crate.